### PR TITLE
created a server class to have a single instance of hono server running

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
   "rules": {
     "unicorn/prevent-abbreviations": "off",
     "unicorn/no-array-reduce": "off",
-    "unicorn/filename-case": "off"
+    "unicorn/filename-case": "off",
+    "unicorn/no-this-assignment": "off"
   }
 }

--- a/prev/cli.js
+++ b/prev/cli.js
@@ -10,6 +10,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parse, print } from 'recast'
 import glob from 'tiny-glob'
+import { log } from './lib/logger.js'
 
 import mdx from '@mdx-js/esbuild'
 import chokidar from 'chokidar'

--- a/prev/kernel/hono.js
+++ b/prev/kernel/hono.js
@@ -5,7 +5,7 @@ import preactRenderToString from 'preact-render-to-string'
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
 import * as esbuild from 'esbuild'
-import { fileURLToPath } from 'node:url'
+import { log } from '../lib/logger.js'
 
 const DYNAMIC_PARAM_START = /\/\+/g
 const ENDS_WITH_EXT = /\.(jsx?|tsx?)$/

--- a/prev/kernel/index.js
+++ b/prev/kernel/index.js
@@ -1,1 +1,1 @@
-export { kernel as createHonoKernel, Server } from './hono.js'
+export { kernel as createHonoKernel } from './hono.js'

--- a/prev/kernel/index.js
+++ b/prev/kernel/index.js
@@ -1,1 +1,1 @@
-export { kernel as createHonoKernel } from './hono.js'
+export { kernel as createHonoKernel, Server } from './hono.js'

--- a/prev/lib/logger.js
+++ b/prev/lib/logger.js
@@ -1,0 +1,8 @@
+export const log = {
+  debug: msg => {
+    const action = process.argv.includes('--debug')
+      ? () => console.log(msg)
+      : () => {}
+    action()
+  },
+}


### PR DESCRIPTION

Parallel restart led to `EADDRINUSE` error. Solved this issue using singleton server, created a Server class to have a single instance of hono server running at a time. Added `init` and `close` function to the class.